### PR TITLE
Get Camera Texture

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,5 +63,5 @@ That all being said, fps seems to be minimally affected if at all, though of cou
 
 
 # Contributing
-As I certainly am not the most knowledgeable on many of the topics required to work in AR on top of ARKit still being in beta. So if there's something you feel you can contribute, by all means, feel free to make PR's! (especially now that my time to work on this will be severely limited for the next few weeks :/)
+As I certainly am not the most knowledgeable on many of the topics required to work in AR, that and with ARKit still being in beta; if there's something you feel you can contribute, by all means, feel free to make PR's! (especially now that my time to work on this will be severely limited for the next few weeks :/)
 As long as it doesn't break anything I'll most likely accept it. Please make all PRs against the `develop` branch

--- a/README.md
+++ b/README.md
@@ -63,5 +63,5 @@ That all being said, fps seems to be minimally affected if at all, though of cou
 
 
 # Contributing
-Feel free to make PR's! (especially now that my time to work on this will be severely limited for the next few weeks :/)
-As long as it doesn't break anything I'll probably accept it. Please make all PRs against the `develop` branch
+As I certainly am not the most knowledgeable on many of the topics required to work in AR on top of ARKit still being in beta. So if there's something you feel you can contribute, by all means, feel free to make PR's! (especially now that my time to work on this will be severely limited for the next few weeks :/)
+As long as it doesn't break anything I'll most likely accept it. Please make all PRs against the `develop` branch

--- a/src/ARProcessor.h
+++ b/src/ARProcessor.h
@@ -35,7 +35,7 @@ class ARProcessor {
     ARAnchorManager anchorController;
     
     // ========== CAMERA IMAGE STUFF ================= //
-    
+    ofFbo cameraFbo;
     CVOpenGLESTextureRef yTexture;
     CVOpenGLESTextureRef CbCrTexture;
     CVOpenGLESTextureCacheRef _videoTextureCache;
@@ -122,7 +122,11 @@ public:
     }
     ARCommon::ARCameraMatrices getCameraMatrices(){
         return cameraMatrices;
-    }  
+    }
+    
+    ofTexture getCameraTexture(){
+        return cameraFbo.getTexture();
+    }
 };
 
 

--- a/src/ARProcessor.mm
+++ b/src/ARProcessor.mm
@@ -112,18 +112,12 @@ CVOpenGLESTextureRef ARProcessor::createTextureFromPixelBuffer(CVPixelBufferRef 
 void ARProcessor::draw(){
     cameraFbo.begin();
         cameraConvertShader.begin();
-        cameraPlane.draw();
+            cameraPlane.draw();
         cameraConvertShader.end();
     cameraFbo.end();
     
-    //flip camera y
-    ofPushMatrix();
-        ofSetRectMode( OF_RECTMODE_CENTER );
-        ofTranslate( cameraFbo.getWidth()/2, cameraFbo.getHeight()/2, 0 );
-        ofScale( 1, -1, 1 );
-            cameraFbo.draw(0,0);
-        ofSetRectMode( OF_RECTMODE_CORNER );
-    ofPopMatrix();
+    cameraFbo.draw(0,0);
+
 }
 
 void ARProcessor::drawCameraFrame(){

--- a/src/ARProcessor.mm
+++ b/src/ARProcessor.mm
@@ -70,6 +70,8 @@ void ARProcessor::setup(){
     if (err){
         NSLog(@"Error at CVOpenGLESTextureCacheCreate %d", err);
     }
+    
+    cameraFbo.allocate(ofGetWindowWidth(), ofGetWindowHeight(), GL_RGBA);
 }
 
 ARFrame* ARProcessor::getCurrentFrame(){
@@ -108,11 +110,20 @@ CVOpenGLESTextureRef ARProcessor::createTextureFromPixelBuffer(CVPixelBufferRef 
 }
 
 void ARProcessor::draw(){
+    cameraFbo.begin();
+        cameraConvertShader.begin();
+        cameraPlane.draw();
+        cameraConvertShader.end();
+    cameraFbo.end();
     
-    cameraConvertShader.begin();
-    cameraPlane.draw();
-    cameraConvertShader.end();
-   
+    //flip camera y
+    ofPushMatrix();
+        ofSetRectMode( OF_RECTMODE_CENTER );
+        ofTranslate( cameraFbo.getWidth()/2, cameraFbo.getHeight()/2, 0 );
+        ofScale( 1, -1, 1 );
+            cameraFbo.draw(0,0);
+        ofSetRectMode( OF_RECTMODE_CORNER );
+    ofPopMatrix();
 }
 
 void ARProcessor::drawCameraFrame(){

--- a/src/ARShaders.h
+++ b/src/ARShaders.h
@@ -49,7 +49,7 @@ const std::string camera_convert_fragment = STRINGIFY(
                                                       void main(){
                                                           
                                                           // flip uvs so image isn't inverted.
-                                                          vec2 textureCoordinate = vec2(vUv.s,1.0 - vUv.t);
+                                                          vec2 textureCoordinate = 1.0 - vec2(vUv.s, vUv.t);
                                                           
                                                           // Using BT.709 which is the standard for HDTV
                                                           mat3 colorConversionMatrix = mat3(


### PR DESCRIPTION
I saw you had a little getCameraTexture method in there in a previous commit that was never fleshed out. I made it available by drawing into an ofFbo. Not sure if there is an easier or better way to grab the camera. For whatever reason drawing into the fbo also flipped the images y (x) coord so I flipped it back in the shader.