### PR TITLE
Horizontal Plane Support

### DIFF
--- a/src/ARAnchorManager.mm
+++ b/src/ARAnchorManager.mm
@@ -97,14 +97,15 @@ void ARAnchorManager::drawPlanes(ARCameraMatrices cameraMatrices){
     for(int i = 0; i < getNumPlanes(); ++i){
         PlaneAnchorObject anchor = getPlaneAt(i);
 
-        
+
         ofPushMatrix();
         ofMultMatrix(anchor.transform);
         ofFill();
-        ofSetColor(255);
+        ofSetColor(102,216,254,100);
         ofRotateX(90);
         ofTranslate(anchor.position.x,anchor.position.y);
         ofDrawRectangle(-anchor.position.x/2,-anchor.position.z/2,0,anchor.width,anchor.height);
+        ofSetColor(255);
         ofPopMatrix();
         
     }

--- a/src/ARProcessor.h
+++ b/src/ARProcessor.h
@@ -32,7 +32,7 @@ class ARProcessor {
     
     CGSize viewportSize;
     // ========== ANCHORS ==================== //
-    ARAnchorManager anchorController;
+    ARAnchorManager * anchorController;
     
     // ========== CAMERA IMAGE STUFF ================= //
     ofFbo cameraFbo;
@@ -104,7 +104,9 @@ public:
     // alias for draw
     void drawCameraFrame();
 
-
+    // draws horizontal planes (if detected)
+    void drawHorizontalPlanes();
+    
     // TODO add matrix retrival for other orientations
     // ps thanks zach for finding this!
     ARCommon::ARCameraMatrices getMatricesForOrientation(UIInterfaceOrientation orientation=UIInterfaceOrientationPortrait, float near=0.01,float far=1000.0);
@@ -127,6 +129,11 @@ public:
     ofTexture getCameraTexture(){
         return cameraFbo.getTexture();
     }
+    
+    std::vector<PlaneAnchorObject> getHorizontalPlanes(){
+        return anchorController->getPlaneAnchors();
+    }
+    
 };
 
 

--- a/src/ARProcessor.mm
+++ b/src/ARProcessor.mm
@@ -12,6 +12,7 @@ ARProcessor::ARProcessor(){
 
 ARProcessor::ARProcessor(ARSession * session){
     this->session = session;
+    anchorController = new ARAnchorManager(session);
 }
 
 ARProcessor::~ARProcessor(){
@@ -120,6 +121,10 @@ void ARProcessor::draw(){
 
 }
 
+void ARProcessor::drawHorizontalPlanes(){
+    anchorController->drawPlanes(getCameraMatrices());
+}
+
 void ARProcessor::drawCameraFrame(){
     draw();
 }
@@ -141,6 +146,9 @@ void ARProcessor::update(){
     
     // only act if we have the current frame
     if(currentFrame){
+        
+        // update anchor controller for plane detection
+        anchorController->update();
         
         // do light estimates
         if (currentFrame.lightEstimate) {


### PR DESCRIPTION
Hey again! It seems like you were pretty much all the way there with the code mentioned in [this issue](https://github.com/sortofsleepy/ofxARKit/issues/6), but I just exposed the planes from the ARAnchorManager class. I added both a `drawHorizontalPlanes()` and a `getHorizontalPlanes()` method to the processor. 

It seems to be working for me. I also changed the color of the planes to be slightly blue and transparent so that they don't occlude whatever you're looking at.

It also occurred to me that `drawHorizontalPlanes()` might be a better fit for your debug utils class. Not sure what your plans for that one are...
