### PR TITLE
added getPoints and getCurrentPoints methods

### DIFF
--- a/src/ARDebugUtils.h
+++ b/src/ARDebugUtils.h
@@ -56,6 +56,65 @@ namespace ARDebugUtils {
             glGenBuffers(1, &vbo);
         }
         
+        std::set<uint64_t> uniqueIds;
+        
+        // this method is for getting feature points once and only once
+        // useful for building up a mesh overtime without getting tons of duplicates
+        // these are unique points found since the start of the ar session
+        vector<ofVec3f> getPoints(ARFrame * currentFrame){
+            pointCloud = currentFrame.rawFeaturePoints;
+            pointCount = pointCloud.count;
+            
+            //copy the old set to compare against
+            std::set<uint64_t> oldSet;
+            oldSet.clear();
+            oldSet = uniqueIds;
+            
+            for(int i = 0; i<pointCount; i++){
+                //get all unique points since start of session
+                uniqueIds.insert(pointCloud.identifiers[i]);
+            }
+            
+            //get the difference between the sets
+            std::set<uint64_t> difference;
+            std::set_difference(uniqueIds.begin(), uniqueIds.end(),
+                                oldSet.begin(), oldSet.end(),
+                                std::inserter(difference, difference.end()));
+            
+            //if there is anything new put it in newpoints
+            vector<ofVec3f> newPoints;
+            newPoints.clear();
+            
+            for(auto d = difference.begin(); d != difference.end(); d++){
+                for(int i = 0; i<pointCount; i++){
+                    
+                    if(*d == pointCloud.identifiers[i]){
+                        vector_float3 p = pointCloud.points[i];
+                        ofVec3f v3 = ofVec3f(p.x, p.y, p.z);
+                        newPoints.push_back(v3);
+                    }
+                }
+            }
+            return newPoints;
+        }
+        
+        // this method is for getting just the current frames points
+        vector<ofVec3f> getCurrentPoints(ARFrame * currentFrame){
+            pointCloud = currentFrame.rawFeaturePoints;
+            pointCount = pointCloud.count;
+            
+            vector<ofVec3f> points;
+            
+            for(int i = 0; i<pointCount; i++){
+                vector_float3 point =  pointCloud.points[i];
+                ofVec3f v = ofVec3f(point.x, point.y, point.z);
+                points.push_back(v);
+            }
+            
+            return points;
+        }
+
+        
         //! update cloud data and vbo
         void updatePointCloud(ARFrame * currentFrame){
             pointCloud = currentFrame.rawFeaturePoints;


### PR DESCRIPTION
I added some methods for getting a list of feature points that arkit has found. This is useful for not only visualizing the feature points, but could also be used for building meshes on the fly or over time.

getPoints() gets a list of unique points since the AR session has started. getCurrentPoints() just grabs the ones that are being found on the current frame. 

Not sure if the debugUtils is the most appropriate place for this or not, but since the other point cloud stuff was already there it seemed reasonable enough.