### PR TITLE
Bug fix for unassigned variable

### DIFF
--- a/src/ARAnchorManager.mm
+++ b/src/ARAnchorManager.mm
@@ -18,6 +18,7 @@ namespace ARCore {
     
     ARAnchorManager::ARAnchorManager(ARSession * session):shouldUpdatePlanes(false){
         this->session = session;
+        maxTrackedPlanes = 0;
     }
     
     int ARAnchorManager::getNumPlanes(){


### PR DESCRIPTION
This being unassigned = sometimes it's a kooky number. In examples, if statement in updatePlanes always returns false, & no planes are shown/updated!