### PR TITLE
Bug fix for unassigned variable

### DIFF
--- a/src/ARAnchorManager.mm
+++ b/src/ARAnchorManager.mm
@@ -16,7 +16,9 @@ namespace ARCore {
         _onPlaneAdded = nullptr;
     }
     
-    ARAnchorManager::ARAnchorManager(ARSession * session):shouldUpdatePlanes(false){
+    ARAnchorManager::ARAnchorManager(ARSession * session):
+    shouldUpdatePlanes(false),
+    maxTrackedPlanes(0){
         this->session = session;
     }
     


### PR DESCRIPTION
Bug fix for unassigned ```maxTrackedPlanes``` variable causing issues with plane tracking