### PR TITLE
Add getFaces() + header fixes

### DIFF
--- a/src/ARAnchorManager.h
+++ b/src/ARAnchorManager.h
@@ -31,7 +31,7 @@ namespace ARCore {
         //! reference to all currently found or added regular anchors
         std::vector<ARObject> anchors;
 
-#ifdef AR_FACE_TRACKING
+#if AR_FACE_TRACKING
         //! Reference to all currently found faces
         std::vector<FaceAnchorObject> faces;
 #endif
@@ -82,7 +82,7 @@ namespace ARCore {
         std::vector<PlaneAnchorObject> getPlaneAnchors(){
             return planes;
         }
-#ifdef AR_FACE_TRACKING
+#if AR_FACE_TRACKING
         std::vector<FaceAnchorObject> getFaces(){
             return faces;
         }
@@ -152,7 +152,7 @@ namespace ARCore {
         //! update function for dealing with planes.
         void updatePlanes();
 
-#ifdef AR_FACE_TRACKING
+#if AR_FACE_TRACKING
         //! updates face tracking info
         void updateFaces();
 #endif

--- a/src/ARAnchorManager.h
+++ b/src/ARAnchorManager.h
@@ -15,7 +15,6 @@
 #include "ARObjects.h"
 using namespace ARObjects;
 
-
 /**
  Basic helper class to help with managing anchors.
  Note that Apple specifies ARKit dimensions in "meters" as opposed to
@@ -25,49 +24,50 @@ namespace ARCore {
     typedef std::shared_ptr<class ARAnchorManager>AnchorManagerRef;
 
     class ARAnchorManager {
-        
+
         //! Stores data of all currently found planes.
         std::vector<PlaneAnchorObject> planes;
-        
+
         //! reference to all currently found or added regular anchors
         std::vector<ARObject> anchors;
-        
+
 #ifdef AR_FACE_TRACKING
         //! Reference to all currently found faces
         std::vector<FaceAnchorObject> faces;
 #endif
+
         
         //! The number of anchors currently found
         NSInteger anchorInstanceCount;
-        
+
         //! The session to draw from
         ARSession * session;
-        
+
         //! camera object to help draw the anchors
         ofCamera camera;
-        
+
         //! The number of planes we want to be tracking at any given point.
         //! If 0 - it means we want to track every available plane
         int maxTrackedPlanes;
-        
+
         //! The callback function to run when a plane is added.
         std::function<void(PlaneAnchorObject plane)> _onPlaneAdded;
     public:
         ARAnchorManager();
         ARAnchorManager(ARSession * session);
-        
+
         //! Flag for whether or not planes should be updated
         bool shouldUpdatePlanes;
-        
+
         //! Adds an anchor based on the current position of the camera - basically at (0,0) with a slight z offset.
         void addAnchor(float zZoom=-0.2);
-        
+
         //! adds an anchor at the specified position.
         void addAnchor(ofVec3f position,ofMatrix4x4 projection,ofMatrix4x4 viewMatrix);
-        
+
         //! adds an ARObject to be tracked by ARKit.
         void addAnchor(ARObject anchor);
-        
+
         static AnchorManagerRef create(ARSession * session){
             if(!session){
                 NSLog(@"Error - AnchorManagerRef requires an ARSession object");
@@ -75,90 +75,94 @@ namespace ARCore {
                 return AnchorManagerRef(new ARAnchorManager(session));
             }
         }
-        
+
         //! Sets the number of planes we want to track. By default, we track all available planes.
         void setNumberOfPlanesToTrack(int num=0);
-        
+
         //! Returns the vector of currently found planes
         std::vector<PlaneAnchorObject> getPlaneAnchors(){
             return planes;
         }
-        
+#ifdef AR_FACE_TRACKING
+        std::vector<FaceAnchorObject> getFaces(){
+            return faces;
+        }
+#endif
+
         //! Returns the current number of anchors.
         int getNumAnchors(){
             return anchors.size();
         }
-        
+
         //! Allows you to loop through the anchors and do something
         //! with each anchor. Pass in a lambda function
         void loopAnchors(std::function<void(ARObject)> func);
-        
+
         //! Allows you to loop through the anchors and do something
         //! with each anchor. Pass in a lambda function. Returns the current index in the loop
         //! as well as it's anchor.
         void loopAnchors(std::function<void(ARObject,int index)> func);
-        
+
         //! Allows you to loop through planes and do something with each plane
         void loopPlaneAnchors(std::function<void(PlaneAnchorObject)> func);
-        
+
         //! Allows you to loop through planes and do something with each plane
         void loopPlaneAnchors(std::function<void(PlaneAnchorObject,int index)> func);
-        
-        
+
+
         //! Returns the PlaneAnchorObject associated with found planes
         PlaneAnchorObject getPlaneAt(int index=0);
-        
+
         //! Toggles whether or not planes should be updated at each iteration.
         void togglePlaneUpate(){
             shouldUpdatePlanes = !shouldUpdatePlanes;
         }
-        
+
         //! same as above but removes the anchor directly from the ARSession instance.
         //! Note that it does not remove a corresponding ARObject though, but simply removes
         //! stuff directly from the session in an effort to provide another way to remove ARKit added objects.
         void removeAnchorDirectly(int index=0);
-        
+
         //! clears all existing plane anchors being tracked.
         void clearPlaneAnchors();
-        
+
         //! Removes a plane anchor based on it's UUID
         void removePlane(NSUUID * anchorId);
-        
+
         //! removes a plane anchor based on it's index in the planes vector
         void removePlane(int index=0);
-        
-        
+
         //! Clears all existing anchors
         void clearAnchors();
-        
+
         //! removes anchor with the specified uuid
         void removeAnchor(NSUUID * anchorId);
-        
+
         //! removes the anchor with the specified index.
         void removeAnchor(int index=0);
-        
+
         //! Get the number of planes detected.
         int getNumPlanes();
-        
+
         //! Draws all currently found planes.
         void drawPlanes(ARCommon::ARCameraMatrices cameraMatrices);
-        
+
         //! general update function, currently increments the counter to keep track of the number of system + user anchors.
         void update();
-        
+
         //! update function for dealing with planes.
         void updatePlanes();
-        
+
 #ifdef AR_FACE_TRACKING
         //! updates face tracking info
         void updateFaces();
 #endif
-        
+
         //! draw a specific plane
         void drawPlaneAt(ARCommon::ARCameraMatrices cameraMatrices,int index=0);
-        
+
         //! Allows you to set a callback function to run when a new plane is added.
-        //! Returns the reference to that plane. 
+        //! Returns the reference to that plane.
         void onPlaneAdded(std::function<void(PlaneAnchorObject plane)> func);
     };
 }

--- a/src/ARAnchorManager.h
+++ b/src/ARAnchorManager.h
@@ -35,7 +35,6 @@ namespace ARCore {
         //! Reference to all currently found faces
         std::vector<FaceAnchorObject> faces;
 #endif
-
         
         //! The number of anchors currently found
         NSInteger anchorInstanceCount;

--- a/src/ARAnchorManager.mm
+++ b/src/ARAnchorManager.mm
@@ -238,7 +238,6 @@ namespace ARCore {
                        face.indices.push_back((int)ii);
 
                    }
-                    // face.indices = std::vector<uint16_t>(indices, indices + sizeof(indices) / sizeof(indices[0]));
 
                     // store reference to raw anchor
                     face.raw = pa;

--- a/src/ARAnchorManager.mm
+++ b/src/ARAnchorManager.mm
@@ -197,7 +197,7 @@ namespace ARCore {
         }
     }
 
-#ifdef AR_FACE_TRACKING
+#if AR_FACE_TRACKING
     void ARAnchorManager::updateFaces(){
         for (NSInteger index = 0; index < anchorInstanceCount; index++) {
             ARAnchor *anchor = session.currentFrame.anchors[index];

--- a/src/ARAnchorManager.mm
+++ b/src/ARAnchorManager.mm
@@ -9,157 +9,157 @@ using namespace std;
 using namespace ARCommon;
 
 namespace ARCore {
-    
+
     ARAnchorManager::ARAnchorManager():
     shouldUpdatePlanes(false),
     maxTrackedPlanes(0){
         _onPlaneAdded = nullptr;
     }
-    
+
     ARAnchorManager::ARAnchorManager(ARSession * session):
     shouldUpdatePlanes(false),
     maxTrackedPlanes(0){
         this->session = session;
     }
-    
+
     int ARAnchorManager::getNumPlanes(){
         return planes.size();
     }
-    
+
     PlaneAnchorObject ARAnchorManager::getPlaneAt(int index){
         return planes.at(index);
     }
-    
+
     void ARAnchorManager::addAnchor(float zZoom){
-        
-        
+
+
         ARFrame * currentFrame = session.currentFrame;
-        
+
         // Create anchor using the camera's current position
         if (currentFrame) {
-            
+
             // Create a transform with a translation of 0.2 meters in front of the camera
             matrix_float4x4 translation = matrix_identity_float4x4;
-            
+
             translation.columns[3].z = zZoom;
-            
+
             matrix_float4x4 transform = matrix_multiply(currentFrame.camera.transform, translation);
-            
+
             // Add a new anchor to the session
             ARAnchor *anchor = [[ARAnchor alloc] initWithTransform:transform];
-            
-            
+
+
             anchors.push_back(buildARObject(anchor, toMat4(transform)));
-            
+
             [session addAnchor:anchor];
         }
     }
-    
+
     // TODO this still needs a bit of work but it's good enough for the time being.
     // Note that z position should still be considered in meters(anyone know of what ARKit defines as 1 meter by chance?)
     void ARAnchorManager::addAnchor(ofVec3f position,ofMatrix4x4 projection,ofMatrix4x4 viewMatrix){
-        
+
         if(session.currentFrame){
-           
+
             ofVec4f pos = ARCommon::screenToWorld(position, projection, viewMatrix);
-           
+
             // build matrix for the anchor
             matrix_float4x4 translation = matrix_identity_float4x4;
-            
+
             translation.columns[3].x = pos.x;
             translation.columns[3].y = pos.y;
             translation.columns[3].z = position.z;
-            
+
             matrix_float4x4 transform = matrix_multiply(session.currentFrame.camera.transform, translation);
-            
+
             // Add a new anchor to the session
             ARAnchor *anchor = [[ARAnchor alloc] initWithTransform:transform];
-            
+
             anchors.push_back(buildARObject(anchor, toMat4(transform)));
-            
+
             [session addAnchor:anchor];
         }
-        
+
     }
-    
+
     void ARAnchorManager::addAnchor(ARObject anchor){
         // add ARObject
         anchors.push_back(anchor);
-        
+
         // add anchor to ARKit
         [session addAnchor:anchor.rawAnchor];
     }
-    
+
     void ARAnchorManager::loopAnchors(std::function<void(ARObject)> func){
-        
+
         for (int i = 0; i < anchors.size(); i++) {
             func(anchors[i]);
         }
-        
+
     }
-    
+
     void ARAnchorManager::loopAnchors(std::function<void(ARObject,int index)> func){
-        
+
         for (int i = 0; i < anchors.size(); i++) {
             func(anchors[i],i);
         }
-        
+
     }
-    
+
     void ARAnchorManager::loopPlaneAnchors(std::function<void(PlaneAnchorObject)> func){
         for (int i = 0; i < planes.size(); i++) {
             func(planes[i]);
         }
     }
-    
+
     void ARAnchorManager::loopPlaneAnchors(std::function<void(PlaneAnchorObject,int index)> func){
         for (int i = 0; i < planes.size(); i++) {
             func(planes[i],i);
         }
     }
-    
-    
-    
+
+
+
     void ARAnchorManager::update(){
-        
+
         // update number of anchors currently tracked
         anchorInstanceCount = session.currentFrame.anchors.count;
-     
+
     }
-    
-    
+
+
     void ARAnchorManager::updatePlanes(){
-        
+
         // if we aren't tracking the maximum number of planes or we want to track all possible planes,
         // run the for loop.
         if(getNumPlanes() < maxTrackedPlanes || maxTrackedPlanes == 0){
             // update any anchors found in the current frame by the system
             for (NSInteger index = 0; index < anchorInstanceCount; index++) {
                 ARAnchor *anchor = session.currentFrame.anchors[index];
-                
+
                 // did we find a PlaneAnchor?
                 // note - you need to turn on planeDetection in your configuration
                 if([anchor isKindOfClass:[ARPlaneAnchor class]]){
                     ARPlaneAnchor* pa = (ARPlaneAnchor*) anchor;
-                    
+
                     // calc values from anchor.
                     ofMatrix4x4 paTransform = convert<matrix_float4x4, ofMatrix4x4>(pa.transform);
                     ofVec3f center = convert<vector_float3,ofVec3f>(pa.center);
                     ofVec3f extent = convert<vector_float3,ofVec3f>(pa.extent);
-                    
-                    
+
+
                     // neat trick to search in vector with c++ 11, seems to work better than for loop
                     // https://stackoverflow.com/questions/15517991/search-a-vector-of-objects-by-object-attribute
                     auto it = find_if(planes.begin(), planes.end(), [=](const PlaneAnchorObject& obj) {
                         return obj.uuid == anchor.identifier;
                     });
-                    
+
                     // if it == planes.end() - it means we aren't tracking this plane just yet.
                     // if that's the case, then add it.
                     if(it == planes.end()){
-                        
+
                         PlaneAnchorObject plane;
-                        
+
                         plane.transform = paTransform;
                         plane.position.x = -extent.x / 2;
                         plane.position.y = -extent.y / 2;
@@ -167,21 +167,21 @@ namespace ARCore {
                         plane.height = extent.z;
                         plane.uuid = anchor.identifier;
                         plane.rawAnchor = pa;
-                        
+
                         if(_onPlaneAdded != nullptr){
                             _onPlaneAdded(plane);
                         }
-                        
+
                         planes.push_back(plane);
                     }
-                    
+
                     // this block triggers when a plane we're already tracking is found,
                     // check to see if we need to update and update if need be
                     if(it != planes.end()){
                         if(shouldUpdatePlanes){
-                            
+
                             planes[index].transform = paTransform;
-                            
+
                             planes[index].position.x = -extent.x / 2;
                             planes[index].position.y = -extent.y / 2;
                             planes[index].width = extent.x;
@@ -190,112 +190,117 @@ namespace ARCore {
                             planes[index].rawAnchor = pa;
                         }
                     }
-                    
+
                 }
-                
+
             }
         }
     }
-    
+
 #ifdef AR_FACE_TRACKING
     void ARAnchorManager::updateFaces(){
         for (NSInteger index = 0; index < anchorInstanceCount; index++) {
             ARAnchor *anchor = session.currentFrame.anchors[index];
-            
+
             if([anchor isKindOfClass:[ARFaceAnchor class]]){
                 ARFaceAnchor * pa = (ARFaceAnchor*) anchor;
-                
                 ARFaceGeometry * geo = pa.geometry;
-                
+
                 // indices are const int16_t
                 // vertices are const vector_float3
                 // uvs are const vector_float2
                 // counts are all NSIntegers
-                
                 auto it = find_if(faces.begin(), faces.end(), [=](const FaceAnchorObject& obj) {
                     return obj.uuid == anchor.identifier;
                 });
-                
+
                 // if we haven't found a face
                 if(it == faces.end()){
                     FaceAnchorObject face;
-                    
+                    face.vertexCount = geo.vertexCount;
+                    face.triangleCount = geo.triangleCount;
+
                     // transform vertices and uvs
                     for(NSInteger i = 0; i < geo.vertexCount; ++i){
                         vector_float3 vert = geo.vertices[i];
                         vector_float2 uv = geo.textureCoordinates[i];
-                        
-                        
+
+
                         face.vertices.push_back(convert<vector_float3, ofVec3f>(vert));
                         face.uvs.push_back(convert<vector_float2, ofVec2f>(uv));
                     }
-                    
+
                     // set indices
                     auto indices = geo.triangleIndices;
-                    face.indices = std::vector<uint16_t>(indices, indices + sizeof(indices) / sizeof(indices[0]));
-                    
+
+                   for(NSInteger i = 0; i < geo.triangleCount*3; ++i){
+                       int16_t ii = indices[i];
+                       face.indices.push_back((int)ii);
+
+                   }
+                    // face.indices = std::vector<uint16_t>(indices, indices + sizeof(indices) / sizeof(indices[0]));
+
                     // store reference to raw anchor
                     face.raw = pa;
-                    
+
                     // store uuid
                     face.uuid = pa.identifier;
-                    
+
                     // push back new face
                     faces.push_back(face);
-                
+
                 }
-                
+
                 // this block triggers when a face we're already tracking is found,
                 if(it != faces.end()){
-                    
+                    faces[index].raw = pa;
                     faces[index].vertices.clear();
                     faces[index].uvs.clear();
                     faces[index].indices.clear();
-                    
+
                     // transform vertices and uvs
                     for(NSInteger i = 0; i < geo.vertexCount; ++i){
                         vector_float3 vert = geo.vertices[i];
                         vector_float2 uv = geo.textureCoordinates[i];
-                        
-                        
+
+
                         faces[index].vertices.push_back(convert<vector_float3, ofVec3f>(vert));
                         faces[index].uvs.push_back(convert<vector_float2, ofVec2f>(uv));
                     }
-                    
+
                     // set indices
-                    auto indices = geo.triangleIndices;
                     faces[index].indices.clear();
-                    
-                    // TODO not sure if this is gonna be too slow, but not sure if indices ever change all that drastically. If not, should look into re-writing values vs building a new vector.
-                    faces[index].indices = std::vector<uint16_t>(indices, indices + sizeof(indices) / sizeof(indices[0]));
-                   
+                    for(NSInteger i = 0; i < geo.triangleCount*3; ++i){
+                        int16_t ii = geo.triangleIndices[i];
+                        faces[index].indices.push_back((int)ii);
+                    }
                 }
-                
+
             }
         }
     }
 #endif
-    
+
     void ARAnchorManager::setNumberOfPlanesToTrack(int num){
         maxTrackedPlanes = num;
     }
-    
+
     void ARAnchorManager::clearAnchors(){
         // clear all anchors from ARKit session.
         for(int i = 0; i < anchors.size();++i){
             [session removeAnchor:anchors[i].rawAnchor];
         }
-        
+
         // ensure any auto-added anchors are cleared
         for(NSInteger i = 0; i < anchorInstanceCount; i++){
             ARAnchor *anchor = session.currentFrame.anchors[i];
             [session removeAnchor:anchor];
         }
-        
+
         // finally, clear vector
         anchors.clear();
     }
-    
+
     void ARAnchorManager::removeAnchor(NSUUID * anchorId){
         for(int i = 0; i < anchors.size();++i){
             if(anchors[i].rawAnchor.identifier == anchorId){
@@ -304,7 +309,7 @@ namespace ARCore {
             }
         }
     }
-    
+
     void ARAnchorManager::removeAnchor(int index){
         anchors.erase(anchors.begin() + index);
         [session removeAnchor:anchors[index].rawAnchor];
@@ -314,7 +319,7 @@ namespace ARCore {
         for(int i = 0; i < planes.size();++i){
             [session removeAnchor:planes[i].rawAnchor];
         }
-        
+
         // finally, clear vector
         planes.clear();
     }
@@ -330,22 +335,22 @@ namespace ARCore {
         planes.erase(planes.begin() + index);
         [session removeAnchor:planes[index].rawAnchor];
     }
-    
+
     void ARAnchorManager::removeAnchorDirectly(int index){
         ARAnchor *anchor = session.currentFrame.anchors[index];
         [session removeAnchor:anchor];
     }
-    
+
     void ARAnchorManager::drawPlaneAt(ARCameraMatrices cameraMatrices,int index){
         camera.begin();
-        
+
         ofSetMatrixMode(OF_MATRIX_PROJECTION);
         ofLoadMatrix(cameraMatrices.cameraProjection);
         ofSetMatrixMode(OF_MATRIX_MODELVIEW);
         ofLoadMatrix(cameraMatrices.cameraView);
-        
+
         PlaneAnchorObject anchor = getPlaneAt(index);
-        
+
         ofPushMatrix();
         ofMultMatrix(anchor.transform);
         ofFill();
@@ -355,23 +360,23 @@ namespace ARCore {
         ofDrawRectangle(-anchor.position.x/2,-anchor.position.z/2,0,anchor.width,anchor.height);
         ofSetColor(255);
         ofPopMatrix();
-        
+
         camera.end();
     }
-    
-    
+
+
     void ARAnchorManager::drawPlanes(ARCameraMatrices cameraMatrices){
         camera.begin();
-        
+
         ofSetMatrixMode(OF_MATRIX_PROJECTION);
         ofLoadMatrix(cameraMatrices.cameraProjection);
         ofSetMatrixMode(OF_MATRIX_MODELVIEW);
         ofLoadMatrix(cameraMatrices.cameraView);
-        
+
         for(int i = 0; i < getNumPlanes(); ++i){
             PlaneAnchorObject anchor = getPlaneAt(i);
-            
-            
+
+
             ofPushMatrix();
             ofMultMatrix(anchor.transform);
             ofFill();
@@ -381,15 +386,15 @@ namespace ARCore {
             ofDrawRectangle(-anchor.position.x/2,-anchor.position.z/2,0,anchor.width,anchor.height);
             ofSetColor(255);
             ofPopMatrix();
-            
+
         }
-        
+
         camera.end();
     }
-    
+
     void ARAnchorManager::onPlaneAdded(std::function<void(PlaneAnchorObject plane)> func){
         _onPlaneAdded = func;
     }
-    
+
 
 }

--- a/src/ARDebugUtils.h
+++ b/src/ARDebugUtils.h
@@ -15,7 +15,6 @@
 
 #define STRINGIFY(A) #A
 
-
 #ifdef OF_TARGET_IPHONE
 #include "ofMain.h"
 #endif
@@ -72,7 +71,6 @@ namespace ARDebugUtils {
             
         }
     };
-    
     
     //! Helper class for recognizing features and drawing the resulting point cloud.
 

--- a/src/ARFaceTrackingBool.h
+++ b/src/ARFaceTrackingBool.h
@@ -1,0 +1,13 @@
+//
+//  ARFaceTracking.h
+//  example-facetracking
+//
+//  Created by Andrés Cuervo on 3/15/18.
+//
+
+#ifndef ARFaceTracking_h
+#define ARFaceTracking_h
+
+#define AR_FACE_TRACKING true
+
+#endif /* ARFaceTracking_h */

--- a/src/ARFaceTrackingBool.h
+++ b/src/ARFaceTrackingBool.h
@@ -5,5 +5,5 @@
 //  Created by Andrés Cuervo on 3/15/18.
 //
 #ifndef AR_FACE_TRACKING
-#define AR_FACE_TRACKING true
+#define AR_FACE_TRACKING false
 #endif /* ARFaceTracking_h */

--- a/src/ARFaceTrackingBool.h
+++ b/src/ARFaceTrackingBool.h
@@ -4,10 +4,6 @@
 //
 //  Created by Andrés Cuervo on 3/15/18.
 //
-
-#ifndef ARFaceTracking_h
-#define ARFaceTracking_h
-
+#ifndef AR_FACE_TRACKING
 #define AR_FACE_TRACKING true
-
 #endif /* ARFaceTracking_h */

--- a/src/ARObjects.h
+++ b/src/ARObjects.h
@@ -41,7 +41,7 @@ namespace ARObjects {
         }
     }ARObject;
     
-#ifdef AR_FACE_TRACKING
+#if AR_FACE_TRACKING
     //! The base class to build a Face geometry
     typedef struct {
         

--- a/src/ARObjects.h
+++ b/src/ARObjects.h
@@ -1,4 +1,3 @@
-//
 //  ARObjects.hpp
 //
 //  Created by Joseph Chow on 8/25/17.
@@ -9,7 +8,6 @@
 
 #include <stdio.h>
 #include "ofMain.h"
-#include <ARKit/ARKit.h>
 
 namespace ARObjects {
     
@@ -53,6 +51,9 @@ namespace ARObjects {
         // reference to vertices
         vector<ofVec3f> vertices;
         
+        int vertexCount;
+        int triangleCount;
+        
         // reference to uvs
         vector<ofVec2f> uvs;
         
@@ -75,9 +76,8 @@ namespace ARObjects {
         }
         
     }FaceAnchorObject;
-    
 #endif
-    //! quickly constructs an standard ARObject 
+    //! quickly constructs an standard ARObject
     static inline ARObject buildARObject(ARAnchor * rawAnchor,ofMatrix4x4 modelMatrix,bool systemAdded=false){
         ARObject obj;
         obj.rawAnchor = rawAnchor;

--- a/src/ARProcessor.h
+++ b/src/ARProcessor.h
@@ -8,7 +8,6 @@
 #ifndef ARProcessor_hpp
 #define ARProcessor_hpp
 
-
 #include "ofMain.h"
 #include "ofxiOS.h"
 #include <memory>
@@ -25,76 +24,76 @@ typedef std::shared_ptr<class ARProcessor>ARRef;
 //! An API class for doing things in ARKit. Consider this the kitchen sink of everything,
 //! consisting of all possible functionality currently offered by the addon.
 class ARProcessor {
-    
+
     //! A reference to the ARSession
     ARSession * session;
 
     //! A flag to indicate whether or not we're in debug mode
     bool debugMode;
-    
+
 public:
     //! Constructor - pass in ARSession reference
     ARProcessor(ARSession * session);
-    
+
     //! Destructor
     ~ARProcessor();
-    
+
     //! creates a new ARRef
     static ARRef create(ARSession * session){
         return ARRef(new ARProcessor(session));
     }
-    
+
     //! Sets up all the necessary components for ARKit
     void setup(bool debugMode=false);
-    
+
     //! Updates all the ARKit components
     void update();
-    
+
     //! Draws the camera frame
     void draw();
-    
+
     //! Alias for drawing the camera frame for better semantics
     void drawFrame();
-    
+
     //! Pauses the ARKit session
     void pauseSession();
-    
+
     //! Restarts ARKit session
-    //! TODO needs testing - unknown if we can just pull the previous config. 
+    //! TODO needs testing - unknown if we can just pull the previous config.
     void restartSession();
-    
+
     //! Toggles debug mode
     void toggleDebug();
     // ========== OBJECTS ==================== //
-    
+
     //! An ARAnchorManager deals with handling Anchor objects in ARKit
     ARCore::AnchorManagerRef anchorController;
-    
+
     //! A debug class to help visualize feature detection.
     ARDebugUtils::PointCloudDebug pointCloud;
-    
+
     //! Debug class to help render common debugging information.
     ARDebugUtils::ARDebugInfo debugInfo;
-    
+
     //! A class to handle camera functionality.
     ARCore::ARCamRef camera;
-    
+
     //! Returns the current tracking state of the ARKit framework.
     ARTrackingState getTrackingState();
-    
+
     //! Logs the current tracking state of the ARKit framework.
     void logTrackingState();
-    
+
     //======== DEBUG API ============ //
-    
+
     //! draws point cloud
     void drawPointCloud();
 
     //======== ANCHORS API ============ //
-    
+
     //! Adds an anchor at the origin. Allows to optionally pass in a custom z value.
     void addAnchor(float zZoom=-0.2);
-    
+
     //! Adds an anchor at a specified position. Note that z value is up to you to set.
     void addAnchor(ofVec3f position);
     //======== PLANE API ============ //
@@ -103,66 +102,69 @@ public:
     std::vector<PlaneAnchorObject> getHorizontalPlanes(){
         return anchorController->getPlaneAnchors();
     }
-    
+
     //! Draws the current set of horizontal planes
     void drawHorizontalPlanes();
-    
+
     //! updates plane information
     void updatePlanes();
-    
+
     //======== FACE API ============ //
+#ifdef AR_FACE_TRACKING
     void updateFaces();
+    std::vector<FaceAnchorObject> getFaces();
+#endif
     
    //======== CAMERA API ============ //
-    
+
     //! In the event a device is used while locking the orientation, this allows you to
     //! force a certain interface orientation so you can still obtain the correct camera matrices.
     void forceInterfaceOrientation(UIInterfaceOrientation orientation);
-    
+
     //! Signals when the device orientation has changed - which also adjusts
     //! rotation of the camera image depending on the orientation.
     void deviceOrientationChanged();
-    
+
     //! Updates the interface orientation based on the current device orientation. This is to ensure
     //! The camera matrices remain correctly oriented to the current orientation.
     void updateDeviceInterfaceOrientation();
-    
+
     //! Forces the camera frame to rotate.
     void rotateCameraFrame(float angle);
-    
+
     //! Get the light intensity currently detected.
     float getLightIntensity();
-    
+
     //! Returns the camera's current transform matrix as a vec3.
     ofVec3f getCameraPosition();
-    
+
     //! Helper to quickly set up ARKit projection and view matrices for 2D drawing in oF
     void setARCameraMatrices();
-    
+
     //! Returns Projection and View matrices for the specified orientation.
     ARCommon::ARCameraMatrices getMatricesForOrientation(UIInterfaceOrientation orientation=UIInterfaceOrientationPortrait, float near=0.01,float far=1000.0);
-    
+
     //! Return the camera image as a texture.
     ofTexture getCameraTexture();
-    
+
     //! Get the camera matrix set
     ARCommon::ARCameraMatrices getCameraMatrices();
-    
+
     // returns the current projection matrix from the camera
     ofMatrix4x4 getProjectionMatrix(){
         return camera->getProjectionMatrix();
     }
-    
+
     //! returns the current view matrix from the camera
     ofMatrix4x4 getViewMatrix(){
         return camera->getViewMatrix();
     }
-    
+
     //! Returns the camera's current transform matrix.
     ofMatrix4x4 getCameraTransformMatrix(){
         return camera->getTransformMatrix();
     }
-    
+
     //! Returns the camera's FBO.
     ofFbo getFBO(){
         return camera->getFBO();

--- a/src/ARProcessor.h
+++ b/src/ARProcessor.h
@@ -110,7 +110,7 @@ public:
     void updatePlanes();
 
     //======== FACE API ============ //
-#ifdef AR_FACE_TRACKING
+#if AR_FACE_TRACKING
     void updateFaces();
     std::vector<FaceAnchorObject> getFaces();
 #endif

--- a/src/ARProcessor.mm
+++ b/src/ARProcessor.mm
@@ -132,7 +132,7 @@ void ARProcessor::drawHorizontalPlanes(){
     anchorController->drawPlanes(camera->getCameraMatrices());
 }
 
-#ifdef AR_FACE_TRACKING
+#if AR_FACE_TRACKING
 // ======= FACE API ========= //
 std::vector<FaceAnchorObject> ARProcessor::getFaces(){
     return anchorController->getFaces();

--- a/src/ARProcessor.mm
+++ b/src/ARProcessor.mm
@@ -11,14 +11,14 @@ using namespace ARCore;
 
 ARProcessor::ARProcessor(ARSession * session){
     this->session = session;
-    
+
     debugInfo = ARDebugUtils::ARDebugInfo(session);
 }
 
 ARProcessor::~ARProcessor(){
     pauseSession();
     session = nullptr;
-    
+
     // remove this instance of the ARCam - if there are other ARCams around, they will still be in memory
     camera.reset();
     anchorController.reset();
@@ -58,9 +58,9 @@ void ARProcessor::update(){
     if(debugMode){
         pointCloud.updatePointCloud(session.currentFrame);
     }
-    
+
     anchorController->update();
-    
+
 }
 
 void ARProcessor::updatePlanes(){
@@ -123,7 +123,7 @@ void ARProcessor::addAnchor(float zZoom){
 
 void ARProcessor::addAnchor(ofVec3f position){
     auto matrices = getCameraMatrices();
- 
+
     ofMatrix4x4 model = toMat4(session.currentFrame.camera.transform);
     anchorController->addAnchor(position,matrices.cameraProjection,model * getCameraMatrices().cameraView);
 }
@@ -134,6 +134,9 @@ void ARProcessor::drawHorizontalPlanes(){
 
 #ifdef AR_FACE_TRACKING
 // ======= FACE API ========= //
+std::vector<FaceAnchorObject> ARProcessor::getFaces(){
+    return anchorController->getFaces();
+}
 void ARProcessor::updateFaces(){
     anchorController->updateFaces();
 }

--- a/src/ARSessionSetup.h
+++ b/src/ARSessionSetup.h
@@ -80,7 +80,7 @@ namespace ARCore {
         
         auto state = format.getState();
         
-#ifdef AR_FACE_TRACKING
+#if AR_FACE_TRACKING
         // first check if we want face tracking and if it's supported.
         // Currently unknown if this affects other possible tracking implementations since
         // it has it's own configuration type.

--- a/src/ARUtils.h
+++ b/src/ARUtils.h
@@ -10,6 +10,7 @@
 
 #define STRINGIFY(A) #A
 #include "ofMain.h"
+#include "ARFaceTrackingBool.h"
 
 namespace ARCommon {
     

--- a/src/ofxARKit.h
+++ b/src/ofxARKit.h
@@ -7,7 +7,7 @@
 #ifndef ofxARKit_h
 #define ofxARKit_h
 
-#define AR_FACE_TRACKING false
+#include "ARFaceTrackingBool.h"
 
 #include <ARKit/ARKit.h>
 #include "ARUtils.h"


### PR DESCRIPTION
This PR does a few things:
- Adds a `getFaces` method to both ARcore & ARProcessor to make the vector of `ARFaceObject`s publicly accessible.
- Note that I couldn’t get `AR_FACE_TRACKING` to propagate down to `ARObjects.h`, so I created `ARFaceTrackingBool.h` to include in both `ofxARKit.h` and `ARObjects.h`. This is so we only have to define `AR_FACE_TRACKING` once.

Questions to consider:
- Right now you have to do `face.raw.transform`, would it be useful to have an accessor for this (e.g. something like `face.getTransform()`)?
- It’s kind of weird that I had to add `getFaces()` to both the ARProcessor & ARCore, is there a cleaner way to do this that I didn’t think of?
----
Note: some of this code came from @ofZach's [shared example `src` folder](https://github.com/sortofsleepy/ofxARKit/issues/39#issuecomment-371448073).