### PR TITLE
Fix broken camera texture by adding bounds check

### DIFF
--- a/src/lib/ARUtils.h
+++ b/src/lib/ARUtils.h
@@ -55,7 +55,7 @@ namespace ofxARKit {
         
         
         //! convert
-        glm::mat4 toGlmMat4( const matrix_float4x4 & mat ) {
+        static glm::mat4 toGlmMat4( const matrix_float4x4 & mat ) {
             return convert<matrix_float4x4, glm::mat4>(mat);
         }
         

--- a/src/lib/MetalCam.mm
+++ b/src/lib/MetalCam.mm
@@ -325,13 +325,11 @@ static const NSUInteger AAPLNumInteropFormats = sizeof(AAPLInteropFormatTable) /
 
 // =========== OPENGL COMPATIBILTY =========== //
 
+#define OPENGL_MAX_TEXTURE_SIZE 4096
+
 -(void) _setupTextures {
-    
-    auto width = 0;
-    auto height = 0;
-    
     /**
-     TODO values are currently a bit fudged. Probably need to figure out better solution
+     TODO width/height values are currently a bit fudged. Probably need to figure out better solution
      
      Figuring out the pixelBuffer size to get an accurate representation from the Metal frame.
      For some reason - default image is really zoomed in compared to when using the MTKView on it's own.
@@ -355,30 +353,21 @@ static const NSUInteger AAPLNumInteropFormats = sizeof(AAPLInteropFormatTable) /
      to be the best solution.
      
      */
-    
-    
-    
-    // Still zoomed in here - also need to flip width/height otherwise it looks like there's distortion
-    //width = CVPixelBufferGetHeight(_session.currentFrame.capturedImage);
-    //height = CVPixelBufferGetWidth(_session.currentFrame.capturedImage);
-    
     // note that imageResolution is returned in a way as if the camera were in landscape mode so you may need to reverse values. Also note that this is not updated automatically, so probably gonna stick with native bounds of screen.
     //CGSize bounds = _session.configuration.videoFormat.imageResolution;
-    
     CGRect screenBounds = [[UIScreen mainScreen] nativeBounds];
-    
     // this is probably a more reasonable approach.
-    width = self.currentDrawable.texture.width - screenBounds.size.width;
-    height = self.currentDrawable.texture.height - screenBounds.size.height;
-    
-    //NSLog(@"Width is %i and height is %i",width,height);
-    
-    
+    auto width = self.currentDrawable.texture.width - screenBounds.size.width;
+    auto height = self.currentDrawable.texture.height - screenBounds.size.height;
+
+    width = (width > OPENGL_MAX_TEXTURE_SIZE) ? OPENGL_MAX_TEXTURE_SIZE : width;
+    height = (height > OPENGL_MAX_TEXTURE_SIZE) ? OPENGL_MAX_TEXTURE_SIZE : height;
+
+    // NSLog(@"Width is %i and height is %i",width,height);
     /**
      Setup some things here. We do it in an update loop to ensure that we get an
      image as close as possible to what the camera is seeing, the MTKView's currentDrawable isn't
      available until the loop starts.
-     
      */
     // setup the shared pixel buffer so we can send this to OpenGL
     CVReturn cvret = CVPixelBufferCreate(kCFAllocatorDefault,


### PR DESCRIPTION
This does two things, since they're both small changes:
- adds a check to see if texture with or height are over 4096 (maximum OpenGL texture size), and sets them to the max if possible. I don't think the way we're calculating this is foolproof still, but this is a solution that I found works up to the iPhone X, so it's a good stopgap for now.
- make `toGlmMat4` `static` since that's needed & was missing from a previous PR of mine. I was testing this issue in parallel, so it'd be nice to have fixed in the master version as well.

---
Addresses #61 